### PR TITLE
#34:  Remove unnecessary stuff in backend docker image

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,3 +1,4 @@
+# Build the app
 FROM node:16-alpine AS builder
 WORKDIR /app
 COPY ./package.json ./
@@ -7,10 +8,20 @@ COPY . .
 COPY .env.build .env
 RUN npm run build
 
+# Install production node_modules
+FROM node:16-alpine as modules-installer
+WORKDIR /app
+COPY ./package.json ./
+COPY ./package-lock.json ./
+RUN npm install --omit=dev
+
+# Put things together
 FROM node:16-alpine
 ARG RAIDSIMP_VERSION
 ENV RAIDSIMP_VERSION ${RAIDSIMP_VERSION}
 WORKDIR /app
-COPY --from=builder /app ./
+COPY --from=modules-installer /app/node_modules ./node_modules
+COPY --from=builder /app/dist ./
+COPY .env.build .env
 EXPOSE 3000
-CMD ["npm", "run", "start:prod"]
+CMD ["NODE_ENV=production", "node", "src/main.js"]


### PR DESCRIPTION
This PR reduces the backend images size from 391MB to 262MB.

Most of the gains come from installing `node_modules` with the flag `-omit=dev` so that `devDependencies` are not included, but this PR also removed basically everything but the build artifacts.